### PR TITLE
Fix compiler network state for logical gates

### DIFF
--- a/test/phreak_test.exs
+++ b/test/phreak_test.exs
@@ -1,8 +1,21 @@
 defmodule PhreakTest do
   use ExUnit.Case
-  doctest Phreak
 
-  test "greets the world" do
-    assert Phreak.hello() == :world
+  test "compiler builds network for OR conditions" do
+    session = Phreak.new()
+
+    rule = %{
+      "name" => "or_rule",
+      "conditions" => %{
+        "or" => [
+          %{"type" => "patient", "constraints" => [%{"field" => "id", "op" => "bind", "var" => "id"}]},
+          %{"type" => "lab", "constraints" => [%{"field" => "patient_id", "op" => "bind", "var" => "id"}]}
+        ]
+      },
+      "actions" => []
+    }
+
+    {:ok, session} = Phreak.add_rule(session, rule)
+    assert map_size(session.network.nodes) >= 4
   end
 end


### PR DESCRIPTION
## Summary
- ensure NOT and gate nodes store their children in the network
- add helper to store nodes
- test compilation of OR condition rule

## Testing
- `mix test` *(fails: `mix: command not found`)*